### PR TITLE
add getContext for webgl2

### DIFF
--- a/__tests__/mock/prototype.js
+++ b/__tests__/mock/prototype.js
@@ -24,6 +24,11 @@ describe('mock', () => {
     expect(ctx).toBeInstanceOf(WebGLRenderingContext);
   });
 
+  it('context creation of type webgl2 returns WebGLRenderingContext', () => {
+    const ctx = canvas.getContext('webgl2');
+    expect(ctx).toBeInstanceOf(WebGLRenderingContext);
+  });
+
   // it('should expect getContext to be called', () => {
   //   canvas.getContext('2d');
   //   expect(canvas.getContext).toBeCalled();

--- a/src/mock/prototype.js
+++ b/src/mock/prototype.js
@@ -23,7 +23,7 @@ export default function mockPrototype() {
       const ctx = new CanvasRenderingContext2D(this, options);
       generatedContexts.set(this, ctx);
       return ctx;
-    } else if (type === 'webgl' || type === 'experimental-webgl') {
+    } else if (type === 'webgl' || type === 'webgl2' || type === 'experimental-webgl') {
       if (generatedContexts.has(this)) return generatedContexts.get(this);
       const ctx = new WebGLRenderingContext(this, options);
       generatedContexts.set(this, ctx);


### PR DESCRIPTION
I am sure there are other things that will need to be added but for now, this works for pixi.js v5

- Added getContext for webgl2
- Returns the same context as WebGL
