### PR TITLE
Remove duplicate getShaderPrecisionFormat definition

### DIFF
--- a/src/classes/WebGLRenderingContext.js
+++ b/src/classes/WebGLRenderingContext.js
@@ -65,7 +65,6 @@ const testFuncs = [
   'getRenderbufferParameter',
   'getShaderParameter',
   'getShaderInfoLog',
-  'getShaderPrecisionFormat',
   'getShaderSource',
   'getSupportedExtensions',
   'getTexParameter',


### PR DESCRIPTION
A mock implementation of `getShaderPrecisionFormat` is provided toward the bottom of the file, but the `"getShaderPrecisionFormat"` string in `testFuncs` overwrites it. This PR removes the string from `testFuncs` so that the mock implementation can be reached. Thanks!