### PR TITLE
Add missing methods

### DIFF
--- a/src/classes/WebGLRenderingContext.js
+++ b/src/classes/WebGLRenderingContext.js
@@ -6,6 +6,7 @@ const testFuncs = [
   'bindFramebuffer',
   'bindRenderbuffer',
   'bindTexture',
+  'bindVertexArray',
   'blendColor',
   'blendEquation',
   'blendEquationSeparate',
@@ -30,6 +31,7 @@ const testFuncs = [
   'createRenderbuffer',
   'createShader',
   'createTexture',
+  'createVertexArray',
   'cullFace',
   'deleteBuffer',
   'deleteFramebuffer',
@@ -512,4 +514,6 @@ export default class WebGLRenderingContext {
       precision: 23,
     };
   }
+  get drawingBufferWidth() {}
+  get drawingBufferHeight() {}
 }


### PR DESCRIPTION
Methods that are part of webgl 2 are:
`bindVertexArray` and `createVertexArray`
We are checking in our code which version of webgl is available and use the relevant method accordingly, so these two are part of the `WebGL2RenderingContext`.

drawingBuffer... are readonly in the object, so they only have getters.

I'm migrating out the headless-gl and so I want this for my jest tests to run without this complicated package.

I'll keep updating this PR with things I find to make my tests pass.